### PR TITLE
Search Query Tool - Info about Promoted (a.k.a Best Bets) results now can get displayed

### DIFF
--- a/Solutions/SharePoint.Search.QueryTool/SearchQueryTool/MainWindow.xaml
+++ b/Solutions/SharePoint.Search.QueryTool/SearchQueryTool/MainWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Classic" x:Class="SearchQueryTool.MainWindow"
         Icon="Images/sp_site.png"
-        Title="SharePoint Search Query Tool v2.9.0" Height="820" Width="1100" MinWidth="800" MinHeight="600">
+        Title="SharePoint Search Query Tool v2.9.0" Height="820" Width="1120" MinWidth="800" MinHeight="600">
     <Window.Resources>
         <DrawingImage x:Key="Overlay">
             <DrawingImage.Drawing>
@@ -1265,6 +1265,8 @@
                     <TabItem Header="Refinement Res..." ToolTip="Refinement Results" x:Name="RefinementResultsTabItem"  
 						ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                     <TabItem Header="Secondary Res..." ToolTip="Secondary Results" x:Name="SecondaryResultsTabItem" 
+						ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                    <TabItem Header="Promoted Res..." ToolTip="Promoted (a.k.a Best Bet) Results" x:Name="PromotedResultsTabItem" 
 						ScrollViewer.VerticalScrollBarVisibility="Auto"/>
                     <TabItem Header="Suggestion Res..." ToolTip="Suggestion Results" x:Name="SuggestionResultsTabItem" 
 						ScrollViewer.VerticalScrollBarVisibility="Auto"/>


### PR DESCRIPTION
Promoted (a.k.a Best Bets) results get returned by the Search REST API and can be seen within the data of the 'Raw' tab, but don't get displayed in any of the currently existing Tabs nor any hints in the 'Status' tab within the 'Second Query Results:' summary

1. Added code-logic to check for and process Promoted (a.k.a Best Bets) results returned within the SecondaryQueryResults.
2. Added info about the 'Total Promoted Results' returned within the 'Status' tab under 'Second Query Results:' summary.
3. Added new tab for Promoted (a.k.a Best Bets) results.
4. Increased window size by 20 to 1120 to avoid two lines for the tabs.

![SDC_PromotedResultsTab](https://user-images.githubusercontent.com/14944476/135285675-7ed95571-e074-4886-b215-64b980ac975f.png)
![SDC_StatusTab](https://user-images.githubusercontent.com/14944476/135285680-ed1a5d8b-bc8b-46e1-bf05-f8202949e372.png)
